### PR TITLE
fix: undefined cpus_list, unquoted house_keeping test, and unused import

### DIFF
--- a/osnoise-client
+++ b/osnoise-client
@@ -132,7 +132,7 @@ WORKLOAD_CPUS=${CMD_OUTPUT}
 echo "WORKLOAD_CPUS: ${WORKLOAD_CPUS}"
 
 # Override HK_CPUS w/ house-keeping param (if defined)
-if [ -n $house_keeping ]; then
+if [ -n "${house_keeping}" ]; then
     echo "'house-keeping' param is defined: ${house_keeping}"
     # Cpu range to comma separated list: e.g. 2-3 ==> 2,3
     cmd="${TOOLBOX_HOME}/bin/cpumask.py --cpus ${house_keeping}"

--- a/osnoise-client
+++ b/osnoise-client
@@ -171,8 +171,8 @@ HK_CPUS=${CMD_OUTPUT}
 echo "HK_CPUS: ${HK_CPUS}"
 
 if [ "$no_load_balance" == "1" ]; then
-     echo "Disabling load balance on cpus ${cpus_list}..."
-     disable_balance $cpus_list
+     echo "Disabling load balance on cpus ${WORKLOAD_CPUS}..."
+     disable_balance $WORKLOAD_CPUS
 fi
 
 echo
@@ -204,8 +204,8 @@ fi
 
 
 if [ "$no_load_balance" == "1" ]; then
-     echo "Enabling load balance on cpus ${cpus_list}..."
-     enable_balance $cpus_list
+     echo "Enabling load balance on cpus ${WORKLOAD_CPUS}..."
+     enable_balance $WORKLOAD_CPUS
 fi
 
 if [ $rc -gt 0 ]; then

--- a/osnoise-post-process
+++ b/osnoise-post-process
@@ -6,7 +6,6 @@ import sys
 import os
 import math
 import json
-import yaml
 import glob
 from datetime import datetime
 from pathlib import Path


### PR DESCRIPTION
## Summary
- Fix `disable_balance`/`enable_balance` called with undefined `$cpus_list` — use `$WORKLOAD_CPUS`
- Quote `$house_keeping` in `[ -n ]` test so auto-detect fallback is reachable
- Remove unused `import yaml` from post-process

Closes #15

## Test plan
- [ ] CI passes
- [ ] Verify osnoise runs with `--no-load-balance 1`
- [ ] Verify osnoise falls back to HK_CPUS when `--house-keeping` is not specified

🤖 Generated with [Claude Code](https://claude.ai/claude-code)